### PR TITLE
make parsing ignore number of sequence digits

### DIFF
--- a/src/main/java/com/netflix/frigga/NameConstants.java
+++ b/src/main/java/com/netflix/frigga/NameConstants.java
@@ -22,7 +22,7 @@ public interface NameConstants {
 
     String NAME_CHARS = "a-zA-Z0-9._";
     String NAME_HYPHEN_CHARS = "-a-zA-Z0-9._";
-    String PUSH_FORMAT = "v([0-9]{3})";
+    String PUSH_FORMAT = "v([0-9]+)";
     String LABELED_VAR_SEPARATOR = "0";
     String LABELED_VARIABLE = "[a-zA-Z][" + LABELED_VAR_SEPARATOR + "][a-zA-Z0-9]+";
 

--- a/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
@@ -110,6 +110,28 @@ class NamesSpec extends Specification {
         406 == names.sequence
 
         when:
+        names = Names.parseName("api-test-A-v40600")
+        then:
+        "api-test-A-v40600" == names.group
+        "api-test-A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "A" == names.detail
+        "v40600" == names.push
+        40600 == names.sequence
+
+        when:
+        names = Names.parseName("api-test-A-v4")
+        then:
+        "api-test-A-v4" == names.group
+        "api-test-A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "A" == names.detail
+        "v4" == names.push
+        4 == names.sequence
+
+        when:
         names = Names.parseName("api-test101")
         then:
         "api-test101" == names.group


### PR DESCRIPTION
Ref SPIN-1754. For some use-cases we may need
to support a larger number of digits for group
sequence numbers. This change makes the parsing
more lenient to the number of digits in the
sequence.

Tools such as spinnaker that are creating the
resources would be responsible for figuring out
the appropriate number of digits and worrying
about padding. This change is to allow tools
that just consume the group names to move forward.

/cc @cfieber @aspyker @spodila 