### PR TITLE
WIP - do not merge: Support customization of name parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'nebula.netflixoss' version '3.2.3'
+    id 'nebula.netflixoss' version '3.4.0'
     id 'java'
     id 'groovy'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip

--- a/src/main/java/com/netflix/frigga/spi/NamesParserProvider.java
+++ b/src/main/java/com/netflix/frigga/spi/NamesParserProvider.java
@@ -1,0 +1,14 @@
+package com.netflix.frigga.spi;
+
+import com.netflix.frigga.Names;
+
+/**
+ * NamesParserProvider.
+ *
+ * Allows customization of the parsing of a name into its components by supplying a
+ * custom parser provider through Java's ServiceLocator mechanism.
+ */
+public interface NamesParserProvider {
+
+    Names parseName(String name);
+}

--- a/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
@@ -15,6 +15,8 @@
  */
 package com.netflix.frigga
 
+import com.netflix.frigga.spi.CustomizedNames
+import com.netflix.frigga.spi.CustomizedNamesParserProvider
 import spock.lang.Specification
 
 class NamesSpec extends Specification {
@@ -408,4 +410,19 @@ class NamesSpec extends Specification {
         null == names.extractLabeledVariable('-p0sony', null)
     }
 
+    void testWithCustomParserProvider() {
+        when:
+        Names namesCustom = Names.parseName(name, new CustomizedNamesParserProvider());
+        Names namesBase = Names.parseName(baseName)
+
+        then:
+        namesCustom.app == namesBase.app
+        namesCustom.stack == namesBase.stack
+        namesCustom.detail == namesBase.detail
+        ((CustomizedNames) namesCustom).isFailoverStack()
+
+        where:
+        baseName = "videometadata-navigator-integration-240-CAN"
+        name = "failover_$baseName"
+    }
 }

--- a/src/test/groovy/com/netflix/frigga/spi/CustomizedNames.java
+++ b/src/test/groovy/com/netflix/frigga/spi/CustomizedNames.java
@@ -1,0 +1,46 @@
+package com.netflix.frigga.spi;
+
+import com.netflix.frigga.Names;
+
+/**
+ * CustomizedNames.
+ *
+ * Example that takes the form of
+ * (failover_)(original-app-naming)
+ */
+public class CustomizedNames extends Names {
+
+    private static final String FAILOVER_PREFIX="failover_";
+
+    static String translateToBase(String name) {
+        if (isFailoverStack(name)) {
+            return name.substring(FAILOVER_PREFIX.length());
+        }
+        return name;
+    }
+
+    static boolean isFailoverStack(String name) {
+        return name.startsWith(FAILOVER_PREFIX);
+    }
+
+    private final boolean failoverStack;
+
+    public CustomizedNames(String name) {
+        super(translateToBase(name));
+        this.failoverStack = isFailoverStack(name);
+    }
+
+    public boolean isFailoverStack() {
+        return failoverStack;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + Boolean.hashCode(failoverStack);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && ((CustomizedNames) obj).isFailoverStack() == failoverStack;
+    }
+}

--- a/src/test/groovy/com/netflix/frigga/spi/CustomizedNamesParserProvider.java
+++ b/src/test/groovy/com/netflix/frigga/spi/CustomizedNamesParserProvider.java
@@ -1,0 +1,13 @@
+package com.netflix.frigga.spi;
+
+import com.netflix.frigga.Names;
+
+/**
+ * CustomizedNamesParserProvider.
+ */
+public class CustomizedNamesParserProvider implements NamesParserProvider {
+    @Override
+    public Names parseName(String name) {
+        return new CustomizedNames(name);
+    }
+}


### PR DESCRIPTION
This is just a prototype of an approach to supporting custom naming formats (and only on the parsing side at the moment)  with the constraint of maintaining binary compatibility for existing callers.

I can't say I really like the way this looks, but I'm not sure how much of that is due to the existing implementation being a static method calling a protected constructor

@nbehnam this is sort of what I was thinking and the example in the test is sort of your use case
@brharrington any thoughts on this? definitely open to something cleaner than what is currently here
