### PR TITLE
allow carets as valid characters in asg names

### DIFF
--- a/src/main/java/com/netflix/frigga/NameConstants.java
+++ b/src/main/java/com/netflix/frigga/NameConstants.java
@@ -21,7 +21,7 @@ package com.netflix.frigga;
 public interface NameConstants {
 
     String NAME_CHARS = "a-zA-Z0-9._";
-    String NAME_HYPHEN_CHARS = "-a-zA-Z0-9._";
+    String NAME_HYPHEN_CHARS = "-a-zA-Z0-9._\\^";
     String PUSH_FORMAT = "v([0-9]+)";
     String LABELED_VAR_SEPARATOR = "0";
     String LABELED_VARIABLE = "[a-zA-Z][" + LABELED_VAR_SEPARATOR + "][a-zA-Z0-9]+";

--- a/src/test/groovy/com/netflix/frigga/NameValidationSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NameValidationSpec.groovy
@@ -50,4 +50,11 @@ class NameValidationSpec extends Specification {
         NameValidation.usesReservedFormat("abcache-c0USA")
         !NameValidation.usesReservedFormat("hellojgritman")
     }
+
+    def 'should validate names with carets'() {
+        expect:
+        NameValidation.checkNameWithHyphen("A^")
+        NameValidation.checkNameWithHyphen("something-^1.0.0.0")
+    }
+
 }


### PR DESCRIPTION
to support nodequark requirement in spinnaker