### PR TITLE
Make frigga configurable ( https://github.com/spinnaker/spinnaker/issues/602 )

### DIFF
--- a/src/main/java/com/netflix/frigga/NameBuilder.java
+++ b/src/main/java/com/netflix/frigga/NameBuilder.java
@@ -25,10 +25,10 @@ public abstract class NameBuilder {
         // Use empty strings, not null references that output "null"
         stack = stack != null ? stack : "";
         if (detail != null && !detail.isEmpty()) {
-            return appName + "-" + stack + "-" + detail;
+            return appName + NameConstants.DELIMITER + stack + NameConstants.DELIMITER  + detail;
         }
         if (!stack.isEmpty()) {
-            return appName + "-" + stack;
+            return appName + NameConstants.DELIMITER  + stack;
         }
         return appName;
     }

--- a/src/main/java/com/netflix/frigga/NameConstants.java
+++ b/src/main/java/com/netflix/frigga/NameConstants.java
@@ -20,8 +20,14 @@ package com.netflix.frigga;
  */
 public interface NameConstants {
 
-    String NAME_CHARS = "a-zA-Z0-9._";
-    String NAME_HYPHEN_CHARS = "-a-zA-Z0-9._\\^";
+    String DELIMITER = System.getenv("FRIGGA_DELIMITER") == ""?  System.getenv("FRIGGA_DELIMITER") : "_";
+    String APPVERSION_DELIMITER = System.getenv("FRIGGA_APPVERSION_DELIMITER") == ""?  System.getenv("FRIGGA_APPVERSION_DELIMITER") : "-";
+    String AUTHORIZED_CHARS = System.getenv("FRIGGA_AUTHORIZED_CHARS") == ""?  System.getenv("FRIGGA_AUTHORIZED_CHARS") :".\\-";
+    String APPVERSION_AUTHORIZED_CHARS = System.getenv("FRIGGA_APPVERSION_AUTHORIZED_CHARS") == ""?  System.getenv("FRIGGA_APPVERSION_AUTHORIZED_CHARS") :"._";
+
+    String NAME_CHARS = "a-zA-Z0-9" + AUTHORIZED_CHARS;
+    String NAME_DELIMITER_CHARS = DELIMITER + "a-zA-Z0-9" + AUTHORIZED_CHARS + "\\^";
+    String APP_NAME_DELIMITER_CHARS = APPVERSION_DELIMITER + "a-zA-Z0-9" + APPVERSION_AUTHORIZED_CHARS + "\\^";
     String PUSH_FORMAT = "v([0-9]+)";
     String LABELED_VAR_SEPARATOR = "0";
     String LABELED_VARIABLE = "[a-zA-Z][" + LABELED_VAR_SEPARATOR + "][a-zA-Z0-9]+";

--- a/src/main/java/com/netflix/frigga/NameValidation.java
+++ b/src/main/java/com/netflix/frigga/NameValidation.java
@@ -22,12 +22,12 @@ import java.util.regex.Pattern;
  */
 public class NameValidation {
 
-    private static final Pattern NAME_HYPHEN_CHARS_PATTERN =
-            Pattern.compile("^[" + NameConstants.NAME_HYPHEN_CHARS + "]+");
+    private static final Pattern NAME_DELIMITER_CHARS_PATTERN =
+            Pattern.compile("^[" + NameConstants.NAME_DELIMITER_CHARS + "]+");
     private static final Pattern NAME_CHARS_PATTERN = Pattern.compile("^[" + NameConstants.NAME_CHARS + "]+");
     private static final Pattern PUSH_FORMAT_PATTERN = Pattern.compile(".*?" + NameConstants.PUSH_FORMAT);
     private static final Pattern LABELED_VARIABLE_PATTERN =
-            Pattern.compile("^(.*?-)?" + NameConstants.LABELED_VARIABLE + ".*?$");
+            Pattern.compile("^(.*?"+ NameConstants.DELIMITER +")?" + NameConstants.LABELED_VARIABLE + ".*?$");
 
     private NameValidation() { }
 
@@ -65,8 +65,8 @@ public class NameValidation {
      * @param name the string to validate
      * @return true if the name is valid
      */
-    public static boolean checkNameWithHyphen(String name) {
-        return checkMatch(name, NAME_HYPHEN_CHARS_PATTERN);
+    public static boolean checkNameWithDelimiter(String name) {
+        return checkMatch(name, NAME_DELIMITER_CHARS_PATTERN);
     }
 
     /**
@@ -74,13 +74,13 @@ public class NameValidation {
      * Restricting the ASG name this way allows safer assumptions in other code about ASG names, like a promise of no
      * spaces, hash marks, percent signs, or dollar signs.
      *
-     * @deprecated use checkNameWithHyphen
+     * @deprecated use checkNameWithDelimiter
      * @param detail the detail string to validate
      * @return true if the detail is valid
      */
     @Deprecated
     public static boolean checkDetail(String detail) {
-        return checkMatch(detail, NAME_HYPHEN_CHARS_PATTERN);
+        return checkMatch(detail, NAME_DELIMITER_CHARS_PATTERN);
     }
 
     /**

--- a/src/main/java/com/netflix/frigga/Names.java
+++ b/src/main/java/com/netflix/frigga/Names.java
@@ -25,12 +25,12 @@ import java.util.regex.Pattern;
 public class Names {
 
     private static final Pattern PUSH_PATTERN = Pattern.compile(
-            "^([" + NameConstants.NAME_HYPHEN_CHARS + "]*)-(" + NameConstants.PUSH_FORMAT + ")$");
+            "^([" + NameConstants.NAME_DELIMITER_CHARS + "]*)" + NameConstants.DELIMITER +"(" + NameConstants.PUSH_FORMAT + ")$");
     private static final Pattern LABELED_VARS_PATTERN = Pattern.compile(
-            "^([" + NameConstants.NAME_HYPHEN_CHARS + "]*?)((-" + NameConstants.LABELED_VARIABLE + ")*)$");
+            "^([" + NameConstants.NAME_DELIMITER_CHARS + "]*?)((" + NameConstants.DELIMITER + NameConstants.LABELED_VARIABLE + ")*)$");
     private static final Pattern NAME_PATTERN = Pattern.compile(
-            "^([" + NameConstants.NAME_CHARS + "]+)(?:-([" + NameConstants.NAME_CHARS + "]*))?(?:-(["
-                    + NameConstants.NAME_HYPHEN_CHARS + "]*?))?$");
+            "^([" + NameConstants.NAME_CHARS + "]+)(?:" + NameConstants.DELIMITER + "([" + NameConstants.NAME_CHARS + "]*))?(?:" + NameConstants.DELIMITER + "(["
+                    + NameConstants.NAME_DELIMITER_CHARS + "]*?))?$");
 
     private String group;
     private String cluster;
@@ -103,7 +103,7 @@ public class Names {
 
     private String extractLabeledVariable(String labeledVariablesString, String labelKey) {
         if (labeledVariablesString != null) {
-            Pattern labelPattern = Pattern.compile(".*?-" + labelKey + NameConstants.LABELED_VAR_SEPARATOR + "(["
+            Pattern labelPattern = Pattern.compile(".*?" + NameConstants.DELIMITER + labelKey + NameConstants.LABELED_VAR_SEPARATOR + "(["
                     + NameConstants.NAME_CHARS + "]*).*?$");
             Matcher labelMatcher = labelPattern.matcher(labeledVariablesString);
             boolean hasLabel = labelMatcher.matches();

--- a/src/main/java/com/netflix/frigga/ami/AppVersion.java
+++ b/src/main/java/com/netflix/frigga/ami/AppVersion.java
@@ -32,8 +32,8 @@ public class AppVersion implements Comparable<AppVersion> {
      * subscriberha-1.0.0-586499.h150/WE-WAPP-subscriberha/150
      */
     private static final Pattern APP_VERSION_PATTERN = Pattern.compile(
-            "([" + NameConstants.NAME_HYPHEN_CHARS
-            + "]+)-([0-9.a-zA-Z~]+)-(\\w+)(?:[.](\\w+))?(?:\\/([" + NameConstants.NAME_HYPHEN_CHARS + "]+)\\/([0-9]+))?");
+            "([" + NameConstants.APP_NAME_DELIMITER_CHARS
+            + "]+)"+ NameConstants.APPVERSION_DELIMITER +"([0-9.a-zA-Z~]+)"+ NameConstants.APPVERSION_DELIMITER +"(\\w+)(?:[.](\\w+))?(?:\\/([" + NameConstants.APP_NAME_DELIMITER_CHARS + "]+)\\/([0-9]+))?");
 
 
     private String packageName;

--- a/src/test/groovy/com/netflix/frigga/NameValidationWithCustomizationSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NameValidationWithCustomizationSpec.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE_2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,12 +17,12 @@ package com.netflix.frigga
 
 import spock.lang.Specification
 
-class NameValidationSpec extends Specification {
+class NameValidationWithCustomizationSpec extends Specification {
 
     def 'should validate names'() {
         expect:
         NameValidation.checkName("abha")
-        NameValidation.checkName("account_batch")
+        NameValidation.checkName("account-batch")
         NameValidation.checkName("account.batch")
         !NameValidation.checkName("account#batch")
         !NameValidation.checkName("")
@@ -33,13 +33,13 @@ class NameValidationSpec extends Specification {
         expect:
         NameValidation.checkNameWithDelimiter("A")
         NameValidation.checkNameWithDelimiter("0")
-        NameValidation.checkNameWithDelimiter("east-1c-0")
-        NameValidation.checkNameWithDelimiter("230CAN-next-A")
-        NameValidation.checkNameWithDelimiter("integration-240-USA")
-        NameValidation.checkNameWithDelimiter("integration-240-usa-iphone-ipad-ios5-even-numbered-days-not-weekends")
-        NameValidation.checkNameWithDelimiter("----")
-        NameValidation.checkNameWithDelimiter("__._._--_..")
-        !NameValidation.checkNameWithDelimiter("230CAN#next-A")
+        NameValidation.checkNameWithDelimiter("east_1c_0")
+        NameValidation.checkNameWithDelimiter("230CAN_next_A")
+        NameValidation.checkNameWithDelimiter("integration_240_USA")
+        NameValidation.checkNameWithDelimiter("integration_240_usa_iphone_ipad_ios5_even_numbered_days_not_weekends")
+        NameValidation.checkNameWithDelimiter("____")
+        NameValidation.checkNameWithDelimiter("--.-.-__-..")
+        !NameValidation.checkNameWithDelimiter("230CAN#next_A")
         !NameValidation.checkNameWithDelimiter("")
         !NameValidation.checkNameWithDelimiter(null)
     }
@@ -47,14 +47,14 @@ class NameValidationSpec extends Specification {
     def 'should validate reserved format'() {
         expect:
         NameValidation.usesReservedFormat("v248")
-        NameValidation.usesReservedFormat("abcache-c0USA")
+        NameValidation.usesReservedFormat("abcache_c0USA")
         !NameValidation.usesReservedFormat("hellojgritman")
     }
 
     def 'should validate names with carets'() {
         expect:
         NameValidation.checkNameWithDelimiter("A^")
-        NameValidation.checkNameWithDelimiter("something-^1.0.0.0")
+        NameValidation.checkNameWithDelimiter("something_^1.0.0.0")
     }
 
 }

--- a/src/test/groovy/com/netflix/frigga/NamesWithCustomizationSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NamesWithCustomizationSpec.groovy
@@ -1,0 +1,411 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE_2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.frigga
+
+import spock.lang.Specification
+
+class NamesWithCustomizationSpec extends Specification {
+
+    def 'should dissect name with dot'() {
+        when: 
+        Names names = Names.parseName("chukwa.collector-1_v889")
+
+        then:
+        "chukwa.collector-1_v889" == names.group
+        "chukwa.collector-1" == names.cluster
+        "chukwa.collector-1" == names.app
+        null == names.stack
+        null == names.detail
+        "v889" == names.push
+        889 == names.sequence
+    }
+
+    def 'should return empty object for invalid'() {
+        when:
+        Names names = Names.parseName('nccp_moviecontrol%27')
+
+        then:
+        null == names.group
+        null == names.cluster
+        null == names.app
+        null == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+    }
+
+    def 'should dissect group names'() {
+        when:
+        Names names = Names.parseName(null)
+        then:
+        null == names.group
+        null == names.cluster
+        null == names.app
+        null == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("actiondrainer")
+        then:
+        "actiondrainer" == names.group
+        "actiondrainer" == names.cluster
+        "actiondrainer" == names.app
+        null == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("actiondrainer_v003")
+        then:
+        "actiondrainer_v003" == names.group
+        "actiondrainer" == names.cluster
+        "actiondrainer" == names.app
+        null == names.stack
+        null == names.detail
+        "v003" == names.push
+        3 == names.sequence
+
+        when:
+        names = Names.parseName("actiondrainer__v003")
+        then:
+        "actiondrainer__v003" == names.group
+        "actiondrainer_" == names.cluster
+        "actiondrainer" == names.app
+        null == names.stack
+        null == names.detail
+        "v003" == names.push
+        3 == names.sequence
+
+        when:
+        names = Names.parseName("actiondrainer___v003")
+        then:
+        "actiondrainer___v003" == names.group
+        "actiondrainer__" == names.cluster
+        "actiondrainer" == names.app
+        null == names.stack
+        null == names.detail
+        "v003" == names.push
+        3 == names.sequence
+
+        when:
+        names = Names.parseName("api_test_A")
+        then:
+        "api_test_A" == names.group
+        "api_test_A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "A" == names.detail
+        null == names.push
+
+        when:
+        names = Names.parseName("api_test_A_v406")
+        then:
+        "api_test_A_v406" == names.group
+        "api_test_A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "A" == names.detail
+        "v406" == names.push
+        406 == names.sequence
+
+        when:
+        names = Names.parseName("api_test_A_v40600")
+        then:
+        "api_test_A_v40600" == names.group
+        "api_test_A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "A" == names.detail
+        "v40600" == names.push
+        40600 == names.sequence
+
+        when:
+        names = Names.parseName("api_test_A_v4")
+        then:
+        "api_test_A_v4" == names.group
+        "api_test_A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "A" == names.detail
+        "v4" == names.push
+        4 == names.sequence
+
+        when:
+        names = Names.parseName("api_test101")
+        then:
+        "api_test101" == names.group
+        "api_test101" == names.cluster
+        "api" == names.app
+        "test101" == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("chukwacollector-1")
+        then:
+        "chukwacollector-1" == names.group
+        "chukwacollector-1" == names.cluster
+        "chukwacollector-1" == names.app
+        null == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("chukwacollector-1_v889")
+        then:
+        "chukwacollector-1_v889" == names.group
+        "chukwacollector-1" == names.cluster
+        "chukwacollector-1" == names.app
+        null == names.stack
+        null == names.detail
+        "v889" == names.push
+        889 == names.sequence
+
+        when:
+        names = Names.parseName("api_test_A")
+        then:
+        "api_test_A" == names.group
+        "api_test_A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "A" == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("discovery_dev")
+        then:
+        "discovery_dev" == names.group
+        "discovery_dev" == names.cluster
+        "discovery" == names.app
+        "dev" == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("discovery_us_east_1d")
+        then:
+        "discovery_us_east_1d" == names.group
+        "discovery_us_east_1d" == names.cluster
+        "discovery" == names.app
+        "us" == names.stack
+        "east_1d" == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("evcache_us_east_1d_0")
+        then:
+        "evcache_us_east_1d_0" == names.group
+        "evcache_us_east_1d_0" == names.cluster
+        "evcache" == names.app
+        "us" == names.stack
+        "east_1d_0" == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("evcache_us_east_1d_0_v223")
+        then:
+        "evcache_us_east_1d_0_v223" == names.group
+        "evcache_us_east_1d_0" == names.cluster
+        "evcache" == names.app
+        "us" == names.stack
+        "east_1d_0" == names.detail
+        "v223" == names.push
+        223 == names.sequence
+
+        when:
+        names = Names.parseName("videometadata_navigator_integration_240_CAN")
+        then:
+        "videometadata_navigator_integration_240_CAN" == names.group
+        "videometadata_navigator_integration_240_CAN" == names.cluster
+        "videometadata" == names.app
+        "navigator" == names.stack
+        "integration_240_CAN" == names.detail
+        null == names.push
+        null == names.sequence
+    }
+
+
+    void testDissectGroupNameWithLabeledVariables() {
+        when:
+        Names names = Names.parseName("actiondrainer")
+        then:
+        "actiondrainer" == names.group
+        "actiondrainer" == names.cluster
+        "actiondrainer" == names.app
+        null == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+        null == names.countries
+        null == names.devPhase
+        null == names.hardware
+        null == names.partners
+        null == names.revision
+        null == names.usedBy
+        null == names.redBlackSwap
+        null == names.zone
+
+        when:
+        names = Names.parseName(
+                'cass_nccpintegration_random_junk_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_w0A_z0useast1a_v003')
+        then:
+        'cass_nccpintegration_random_junk_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_w0A_z0useast1a_v003' == names.group
+        'cass_nccpintegration_random_junk_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_w0A_z0useast1a' == names.cluster
+        'cass' == names.app
+        'nccpintegration' == names.stack
+        'random_junk' == names.detail
+        'v003' == names.push
+        3 == names.sequence
+        'northamerica' == names.countries
+        'prod' == names.devPhase
+        'gamesystems' == names.hardware
+        'vizio' == names.partners
+        '27' == names.revision
+        'nccp' == names.usedBy
+        'A' == names.redBlackSwap
+        'useast1a' == names.zone
+
+        when:
+        names = Names.parseName('cass_nccpintegration_c0northamerica_d0prod')
+        then:
+        'cass_nccpintegration_c0northamerica_d0prod' == names.group
+        'cass_nccpintegration_c0northamerica_d0prod' == names.cluster
+        'cass' == names.app
+        'nccpintegration' == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+        'northamerica' == names.countries
+        'prod' == names.devPhase
+        null == names.hardware
+        null == names.partners
+        null == names.revision
+        null == names.usedBy
+        null == names.redBlackSwap
+        null == names.zone
+
+        when:
+        names = Names.parseName('cass__my_stuff_c0northamerica_d0prod')
+        then:
+        'cass__my_stuff_c0northamerica_d0prod' == names.group
+        'cass__my_stuff_c0northamerica_d0prod' == names.cluster
+        'cass' == names.app
+        null == names.stack
+        'my_stuff' == names.detail
+        null == names.push
+        null == names.sequence
+        'northamerica' == names.countries
+        'prod' == names.devPhase
+        null == names.hardware
+        null == names.partners
+        null == names.revision
+        null == names.usedBy
+        null == names.redBlackSwap
+        null == names.zone
+
+        when:
+        names = Names.parseName('cass_c0northamerica_d0prod')
+        then:
+        'cass_c0northamerica_d0prod' == names.group
+        'cass_c0northamerica_d0prod' == names.cluster
+        'cass' == names.app
+        null == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+        'northamerica' == names.countries
+        'prod' == names.devPhase
+        null == names.hardware
+        null == names.partners
+        null == names.revision
+        null == names.usedBy
+        null == names.redBlackSwap
+        null == names.zone
+
+        when:
+        names = Names.parseName('cass_c0northamerica_d0prod_v102')
+        then:
+        'cass_c0northamerica_d0prod_v102' == names.group
+        'cass_c0northamerica_d0prod' == names.cluster
+        'cass' == names.app
+        null == names.stack
+        null == names.detail
+        'v102' == names.push
+        102 == names.sequence
+        'northamerica' == names.countries
+        'prod' == names.devPhase
+        null == names.hardware
+        null == names.partners
+        null == names.revision
+        null == names.usedBy
+        null == names.redBlackSwap
+        null == names.zone
+
+        when:
+        names = Names.parseName('cass_v102')
+        then:
+        'cass_v102' == names.group
+        'cass' == names.cluster
+        'cass' == names.app
+        null == names.stack
+        null == names.detail
+        'v102' == names.push
+        102 == names.sequence
+        null == names.countries
+        null == names.devPhase
+        null == names.hardware
+        null == names.partners
+        null == names.revision
+        null == names.usedBy
+        null == names.redBlackSwap
+        null == names.zone
+    }
+
+    void testExtractLabeledVariable() {
+        when:
+        Names names = Names.parseName("test")
+
+        then:
+        'sony' == names.extractLabeledVariable('_p0sony', 'p')
+        'northamerica' == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'c')
+        'prod' == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'd')
+        'gamesystems' == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'h')
+        'vizio' == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'p')
+        '27' == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'r')
+        'nccp' == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'u')
+        'A' == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'x')
+        'useast1a' == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'z')
+        null == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', 'a')
+        null == names.extractLabeledVariable('', 'a')
+        null == names.extractLabeledVariable(null, 'a')
+        null == names.extractLabeledVariable(null, '')
+        null == names.extractLabeledVariable(null, null)
+        null == names.extractLabeledVariable('', null)
+        null == names.extractLabeledVariable('_c0northamerica_d0prod_h0gamesystems_p0vizio_r027_u0nccp_x0A_z0useast1a', null)
+        null == names.extractLabeledVariable('_p0sony', '')
+        null == names.extractLabeledVariable('_p0sony', null)
+    }
+
+}


### PR DESCRIPTION

The idea is to define in an external configuration the following properties :
*  `DELIMITER`  delimiter used in infrastructure items names (ASG, ELB, ...) : currently hard coded to `-` in Frigga
*  `APPVERSION_DELIMITER`  delimiter used in app versions: currently hard coded to `-` in Frigga
*  `AUTHORIZED_CHARS`  authorized chars in infrastructure items names (ASG, ELB, ...) : currently hard coded to `._` in Frigga
*  `APPVERSION_AUTHORIZED_CHARS`  authorized chars in app versions : currently hard coded to `._` in Frigga

I duplicated the existing tests `NamesSpec` and `NameValidationSpec` , swap `-` by `_` in tests data, then replace the default values in `NameConstants` for POCing my idea with :
`DELIMITER` = `_`  and `AUTHORIZED_CHARS` = `.\\-` . The new tests went green.

Currently I tried to use Env vars to set the configurable properties but it would be better to use a config file and add tests with different configurations.

@cfieber would it be an acceptable solution?