### PR TITLE
add support for ~ in detail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'nebula.netflixoss' version '3.2.3'
+    id 'nebula.netflixoss' version '3.6.0'
     id 'java'
     id 'groovy'
 }

--- a/src/main/java/com/netflix/frigga/NameConstants.java
+++ b/src/main/java/com/netflix/frigga/NameConstants.java
@@ -21,7 +21,7 @@ package com.netflix.frigga;
 public interface NameConstants {
 
     String NAME_CHARS = "a-zA-Z0-9._";
-    String NAME_HYPHEN_CHARS = "-a-zA-Z0-9._\\^";
+    String NAME_HYPHEN_CHARS = "-a-zA-Z0-9._~\\^";
     String PUSH_FORMAT = "v([0-9]+)";
     String LABELED_VAR_SEPARATOR = "0";
     String LABELED_VARIABLE = "[a-zA-Z][" + LABELED_VAR_SEPARATOR + "][a-zA-Z0-9]+";

--- a/src/main/java/com/netflix/frigga/Names.java
+++ b/src/main/java/com/netflix/frigga/Names.java
@@ -29,8 +29,8 @@ public class Names {
     private static final Pattern LABELED_VARS_PATTERN = Pattern.compile(
             "^([" + NameConstants.NAME_HYPHEN_CHARS + "]*?)((-" + NameConstants.LABELED_VARIABLE + ")*)$");
     private static final Pattern NAME_PATTERN = Pattern.compile(
-            "^([" + NameConstants.NAME_CHARS + "]+)(?:-([" + NameConstants.NAME_CHARS + "]*))?(?:-(["
-                    + NameConstants.NAME_HYPHEN_CHARS + "]*?))?$");
+            "^([" + NameConstants.NAME_CHARS + "]+)(?:-([" + NameConstants.NAME_CHARS + "]*)(?:-(["
+                    + NameConstants.NAME_HYPHEN_CHARS + "]*?))?)?$");
 
     private String group;
     private String cluster;
@@ -63,6 +63,14 @@ public class Names {
             return;
         }
 
+        String unlabeledVars = labeledVarsMatcher.group(1);
+        String labeledVariables = labeledVarsMatcher.group(2);
+
+        Matcher nameMatcher = NAME_PATTERN.matcher(unlabeledVars);
+        if (!nameMatcher.matches()) {
+            return;
+        }
+
         group = name;
         cluster = theCluster;
         push = hasPush ? pushMatcher.group(2) : null;
@@ -70,12 +78,6 @@ public class Names {
         if (sequenceString != null) {
             sequence = Integer.parseInt(sequenceString);
         }
-
-        String unlabeledVars = labeledVarsMatcher.group(1);
-        String labeledVariables = labeledVarsMatcher.group(2);
-
-        Matcher nameMatcher = NAME_PATTERN.matcher(unlabeledVars);
-        nameMatcher.matches();
         app = nameMatcher.group(1);
         stack = checkEmpty(nameMatcher.group(2));
         detail = checkEmpty(nameMatcher.group(3));

--- a/src/test/groovy/com/netflix/frigga/NameValidationSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NameValidationSpec.groovy
@@ -57,4 +57,10 @@ class NameValidationSpec extends Specification {
         NameValidation.checkNameWithHyphen("something-^1.0.0.0")
     }
 
+    def 'should validate names with tilde'() {
+        expect:
+        NameValidation.checkNameWithHyphen("A~")
+        NameValidation.checkNameWithHyphen("something-~1.0.0.0")
+    }
+
 }

--- a/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
@@ -147,6 +147,72 @@ class NamesSpec extends Specification {
         4 == names.sequence
 
         when:
+        names = Names.parseName("api-test-~A-v4")
+        then:
+        "api-test-~A-v4" == names.group
+        "api-test-~A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "~A" == names.detail
+        "v4" == names.push
+        4 == names.sequence
+
+        when:
+        names = Names.parseName("api-test-^A-v4")
+        then:
+        "api-test-^A-v4" == names.group
+        "api-test-^A" == names.cluster
+        "api" == names.app
+        "test" == names.stack
+        "^A" == names.detail
+        "v4" == names.push
+        4 == names.sequence
+
+        when:
+        names = Names.parseName("api-^test-A-v4")
+        then:
+        null == names.group
+        null == names.cluster
+        null == names.app
+        null == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("api-~test-A-v4")
+        then:
+        null == names.group
+        null == names.cluster
+        null == names.app
+        null == names.stack
+        null == names.detail
+        null == names.push
+        null == names.sequence
+
+        when:
+        names = Names.parseName("api--~A-v4")
+        then:
+        "api--~A-v4" == names.group
+        "api--~A" == names.cluster
+        "api" == names.app
+        null == names.stack
+        "~A" == names.detail
+        "v4" == names.push
+        4 == names.sequence
+
+        when:
+        names = Names.parseName("api--^A-v4")
+        then:
+        "api--^A-v4" == names.group
+        "api--^A" == names.cluster
+        "api" == names.app
+        null == names.stack
+        "^A" == names.detail
+        "v4" == names.push
+        4 == names.sequence
+
+        when:
         names = Names.parseName("api-test101")
         then:
         "api-test101" == names.group


### PR DESCRIPTION
Follow up to #18 and Netflix/atlas#513 adding support
for the `~` character as part of the detail. The general
agreement is there will be no further relaxation of the
rules for group names.

This change also updates the test cases and name pattern
to fix a bug where using a `~` or `^` in the stack was
causing it to be treated as the detail instead of failing
to match. Before:

```
application-^stack-detail

- app = "application"
- stack = null
- detail = "^stack-detail"
```

Now it will be treated just like any other invalid group
name.