### PR TITLE
Short-circuit labeled variable matching if string is empty

### DIFF
--- a/src/main/java/com/netflix/frigga/Names.java
+++ b/src/main/java/com/netflix/frigga/Names.java
@@ -104,7 +104,7 @@ public class Names {
     }
 
     private String extractLabeledVariable(String labeledVariablesString, String labelKey) {
-        if (labeledVariablesString != null) {
+        if (labeledVariablesString != null && !labeledVariablesString.isEmpty()) {
             Pattern labelPattern = Pattern.compile(".*?-" + labelKey + NameConstants.LABELED_VAR_SEPARATOR + "(["
                     + NameConstants.NAME_CHARS + "]*).*?$");
             Matcher labelMatcher = labelPattern.matcher(labeledVariablesString);


### PR DESCRIPTION
`extractLabeledVariable` currently short-circuits if the input labeled variable string is null; as the labeled variables capturing group matches `(labeledvariable)*`  the capturing group will return the empty string if there are no labeled variables.

As a performance improvement, also short-circuit if the labeled variables are an empty string.