### PR TITLE
Make patterns in Names static

### DIFF
--- a/src/main/java/com/netflix/frigga/Names.java
+++ b/src/main/java/com/netflix/frigga/Names.java
@@ -31,6 +31,14 @@ public class Names {
     private static final Pattern NAME_PATTERN = Pattern.compile(
             "^([" + NameConstants.NAME_CHARS + "]+)(?:-([" + NameConstants.NAME_CHARS + "]*)(?:-(["
                     + NameConstants.NAME_HYPHEN_CHARS + "]*?))?)?$");
+    private static final Pattern LABELED_COUNTRIES_PATTERN = createLabeledVariablePattern(NameConstants.COUNTRIES_KEY);
+    private static final Pattern LABELED_DEV_PHASE_KEY_PATTERN = createLabeledVariablePattern(NameConstants.DEV_PHASE_KEY);
+    private static final Pattern LABELED_HARDWARE_KEY_PATTERN = createLabeledVariablePattern(NameConstants.HARDWARE_KEY);
+    private static final Pattern LABELED_PARTNERS_KEY_PATTERN = createLabeledVariablePattern(NameConstants.PARTNERS_KEY);
+    private static final Pattern LABELED_REVISION_KEY_PATTERN = createLabeledVariablePattern(NameConstants.REVISION_KEY);
+    private static final Pattern LABELED_USED_BY_KEY_PATTERN = createLabeledVariablePattern(NameConstants.USED_BY_KEY);
+    private static final Pattern LABELED_RED_BLACK_SWAP_KEY_PATTERN = createLabeledVariablePattern(NameConstants.RED_BLACK_SWAP_KEY);
+    private static final Pattern LABELED_ZONE_KEY_PATTERN = createLabeledVariablePattern(NameConstants.ZONE_KEY);
 
     private String group;
     private String cluster;
@@ -82,14 +90,14 @@ public class Names {
         stack = checkEmpty(nameMatcher.group(2));
         detail = checkEmpty(nameMatcher.group(3));
 
-        countries    = extractLabeledVariable(labeledVariables, NameConstants.COUNTRIES_KEY);
-        devPhase     = extractLabeledVariable(labeledVariables, NameConstants.DEV_PHASE_KEY);
-        hardware     = extractLabeledVariable(labeledVariables, NameConstants.HARDWARE_KEY);
-        partners     = extractLabeledVariable(labeledVariables, NameConstants.PARTNERS_KEY);
-        revision     = extractLabeledVariable(labeledVariables, NameConstants.REVISION_KEY);
-        usedBy       = extractLabeledVariable(labeledVariables, NameConstants.USED_BY_KEY);
-        redBlackSwap = extractLabeledVariable(labeledVariables, NameConstants.RED_BLACK_SWAP_KEY);
-        zone         = extractLabeledVariable(labeledVariables, NameConstants.ZONE_KEY);
+        countries    = extractLabeledVariable(labeledVariables, LABELED_COUNTRIES_PATTERN);
+        devPhase     = extractLabeledVariable(labeledVariables, LABELED_DEV_PHASE_KEY_PATTERN);
+        hardware     = extractLabeledVariable(labeledVariables, LABELED_HARDWARE_KEY_PATTERN);
+        partners     = extractLabeledVariable(labeledVariables, LABELED_PARTNERS_KEY_PATTERN);
+        revision     = extractLabeledVariable(labeledVariables, LABELED_REVISION_KEY_PATTERN);
+        usedBy       = extractLabeledVariable(labeledVariables, LABELED_USED_BY_KEY_PATTERN);
+        redBlackSwap = extractLabeledVariable(labeledVariables, LABELED_RED_BLACK_SWAP_KEY_PATTERN);
+        zone         = extractLabeledVariable(labeledVariables, LABELED_ZONE_KEY_PATTERN);
     }
 
     /**
@@ -103,10 +111,8 @@ public class Names {
         return new Names(name);
     }
 
-    private String extractLabeledVariable(String labeledVariablesString, String labelKey) {
+    private String extractLabeledVariable(String labeledVariablesString, Pattern labelPattern) {
         if (labeledVariablesString != null && !labeledVariablesString.isEmpty()) {
-            Pattern labelPattern = Pattern.compile(".*?-" + labelKey + NameConstants.LABELED_VAR_SEPARATOR + "(["
-                    + NameConstants.NAME_CHARS + "]*).*?$");
             Matcher labelMatcher = labelPattern.matcher(labeledVariablesString);
             boolean hasLabel = labelMatcher.matches();
             if (hasLabel) {
@@ -297,4 +303,9 @@ public class Names {
                 + ", usedBy=" + usedBy + ", redBlackSwap=" + redBlackSwap + ", zone=" + zone + "]";
     }
 
+    private static Pattern createLabeledVariablePattern(String label) {
+        return Pattern.compile(
+            ".*?-" + label + NameConstants.LABELED_VAR_SEPARATOR + "(["
+                + NameConstants.NAME_CHARS + "]*).*?$");
+    }
 }

--- a/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
@@ -454,24 +454,14 @@ class NamesSpec extends Specification {
         Names names = Names.parseName("test")
 
         then:
-        'sony' == names.extractLabeledVariable('-p0sony', 'p')
-        'northamerica' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'c')
-        'prod' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'd')
-        'gamesystems' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'h')
-        'vizio' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'p')
-        '27' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'r')
-        'nccp' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'u')
-        'A' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'x')
-        'useast1a' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'z')
-        null == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', 'a')
-        null == names.extractLabeledVariable('', 'a')
-        null == names.extractLabeledVariable(null, 'a')
-        null == names.extractLabeledVariable(null, '')
-        null == names.extractLabeledVariable(null, null)
-        null == names.extractLabeledVariable('', null)
-        null == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', null)
-        null == names.extractLabeledVariable('-p0sony', '')
-        null == names.extractLabeledVariable('-p0sony', null)
+        'sony' == names.extractLabeledVariable('-p0sony', Names.LABELED_PARTNERS_KEY_PATTERN)
+        'northamerica' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', Names.LABELED_COUNTRIES_PATTERN)
+        'prod' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', Names.LABELED_DEV_PHASE_KEY_PATTERN)
+        'gamesystems' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', Names.LABELED_HARDWARE_KEY_PATTERN)
+        'vizio' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', Names.LABELED_PARTNERS_KEY_PATTERN)
+        '27' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', Names.LABELED_REVISION_KEY_PATTERN)
+        'nccp' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', Names.LABELED_USED_BY_KEY_PATTERN)
+        'useast1a' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', Names.LABELED_ZONE_KEY_PATTERN)
     }
 
 }


### PR DESCRIPTION
While helping a user profile a Clouddriver pod handling large numbers of GCE resources, we discovered that a non-trivial proportion of allocations in some threads stem from calls to `Pattern.compile` in `Names.extractLabeledVariable`, which will happen eight times every time a new Names instance is created (so, every time we call [`Keys.parse`](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-google/src/main/groovy/com/netflix/spinnaker/clouddriver/google/cache/Keys.groovy#L81) from Clouddriver's GCE provider). This change adds these patterns as static members of `Names`. It also removes the tests that call `extractLabeledVariable` with invalid values; since it's a private method and only called from the constructor with static values it seemed like this would be fine, but let me know if I'm missing something!