### PR TITLE
Don't assume sequence is always parsable

### DIFF
--- a/src/main/java/com/netflix/frigga/Names.java
+++ b/src/main/java/com/netflix/frigga/Names.java
@@ -84,7 +84,11 @@ public class Names {
         push = hasPush ? pushMatcher.group(2) : null;
         String sequenceString = hasPush ? pushMatcher.group(3) : null;
         if (sequenceString != null) {
-            sequence = Integer.parseInt(sequenceString);
+            try {
+                sequence = Integer.parseInt(sequenceString);
+            } catch (NumberFormatException e) {
+                // This is fine.
+            }
         }
         app = nameMatcher.group(1);
         stack = checkEmpty(nameMatcher.group(2));

--- a/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
@@ -464,4 +464,14 @@ class NamesSpec extends Specification {
         'useast1a' == names.extractLabeledVariable('-c0northamerica-d0prod-h0gamesystems-p0vizio-r027-u0nccp-x0A-z0useast1a', Names.LABELED_ZONE_KEY_PATTERN)
     }
 
+    def "should not crash on invalid sequence"() {
+        when:
+        Names names = Names.parseName("acme-eks-cluster-v220191017081605302100000002")
+
+        then:
+        names.app == "acme"
+        names.stack == "eks"
+        names.detail == "cluster"
+        names.sequence == null
+    }
 }


### PR DESCRIPTION
We had a rogue security group with group_name set to something similar to `acme-eks-cluster-v220191017081605302100000002`. The number here was being parsed as an integer and blew up because it was too big, which in turn broke the entire `/securityGroups` endpoint in Clouddriver.