### PR TITLE
validate stack and detail do not contain push

### DIFF
--- a/src/main/java/com/netflix/frigga/autoscaling/AutoScalingGroupNameBuilder.java
+++ b/src/main/java/com/netflix/frigga/autoscaling/AutoScalingGroupNameBuilder.java
@@ -20,10 +20,15 @@ import com.netflix.frigga.NameBuilder;
 import com.netflix.frigga.NameConstants;
 import com.netflix.frigga.NameValidation;
 
+import java.util.regex.Pattern;
+
 /**
  * Logic for constructing the name of a new auto scaling group in Asgard.
  */
 public class AutoScalingGroupNameBuilder extends NameBuilder {
+
+    private static final Pattern CONTAINS_PUSH_PATTERN =
+        Pattern.compile("(^|-)" + NameConstants.PUSH_FORMAT + "(-|$)");
 
     private String appName;
     private String stack;
@@ -61,6 +66,8 @@ public class AutoScalingGroupNameBuilder extends NameBuilder {
             if (detail != null && !detail.isEmpty() && !NameValidation.checkDetail(detail)) {
                 throw new IllegalArgumentException("(Use alphanumeric characters only)");
             }
+            validateDoesNotContainPush("stack", stack);
+            validateDoesNotContainPush("detail", detail);
         }
 
         // Build the labeled variables for the end of the group name.
@@ -77,6 +84,12 @@ public class AutoScalingGroupNameBuilder extends NameBuilder {
         String result = combineAppStackDetail(appName, stack, detail) + labeledVars;
 
         return result;
+    }
+
+    private static void validateDoesNotContainPush(String field, String name) {
+        if (name != null && !name.isEmpty() && CONTAINS_PUSH_PATTERN.matcher(name).find()) {
+            throw new IllegalArgumentException(field + " cannot contain a push version");
+        }
     }
 
     private static void validateNames(String... names) {
@@ -123,6 +136,7 @@ public class AutoScalingGroupNameBuilder extends NameBuilder {
     public void setStack(String stack) {
         this.stack = stack;
     }
+
     public AutoScalingGroupNameBuilder withStack(String stack) {
         this.stack = stack;
         return this;

--- a/src/test/groovy/com/netflix/frigga/autoscaling/AutoScalingGroupNameBuilderSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/autoscaling/AutoScalingGroupNameBuilderSpec.groovy
@@ -40,4 +40,43 @@ class AutoScalingGroupNameBuilderSpec extends Specification {
         then:
         "app-stack-detail" == cluster.buildGroupName()
     }
+
+    def 'stack cannot contain a push'() {
+        when:
+        AutoScalingGroupNameBuilder cluster = new AutoScalingGroupNameBuilder()
+        cluster.withAppName("app").withStack("v123")
+        cluster.buildGroupName(true)
+
+        then:
+        def ex = thrown(IllegalArgumentException.class)
+        ex.message == "stack cannot contain a push version"
+    }
+
+    def 'detail cannot contain a push'() {
+        when:
+        AutoScalingGroupNameBuilder cluster = new AutoScalingGroupNameBuilder()
+        cluster.withAppName("app").withDetail("v123")
+        cluster.buildGroupName(true)
+
+        then:
+        def ex = thrown(IllegalArgumentException.class)
+        ex.message == "detail cannot contain a push version"
+
+        when:
+        cluster = new AutoScalingGroupNameBuilder()
+        cluster.withAppName("app").withDetail("abc-v123-def")
+        cluster.buildGroupName(true)
+
+        then:
+        ex = thrown(IllegalArgumentException.class)
+        ex.message == "detail cannot contain a push version"
+
+        when:
+        cluster = new AutoScalingGroupNameBuilder()
+        cluster.withAppName("app").withDetail("abc-v12b3-def")
+        cluster.buildGroupName(true)
+
+        then:
+        noExceptionThrown()
+    }
 }


### PR DESCRIPTION
If the stack or detail contain something that looks like
a push version, then the name cannot be parsed reliably.
This updates the validation for the builder to fail if
there is something that looks like a push version.