### PR TITLE
update gradle and nebula

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'nebula.netflixoss' version '7.1.3'
+    id 'nebula.netflixoss' version '8.6.0'
     id 'java'
     id 'groovy'
 }
@@ -14,6 +14,14 @@ repositories {
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
+
+compileJava {
+    // Generate java8 bytecode and compile against the java8 class
+    // libraries.
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.compilerArgs.addAll(['--release', '8'])
+    }
+}
 
 tasks.compileGroovy.enabled = false
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bump to latest versions of gradle/nebula. Also adds check
to ensure the built artifact is java 8 compatible if using
a newer jdk.