### PR TITLE
support 3-6 digit push sequence

### DIFF
--- a/src/main/java/com/netflix/frigga/NameConstants.java
+++ b/src/main/java/com/netflix/frigga/NameConstants.java
@@ -23,7 +23,7 @@ public interface NameConstants {
     String NAME_CHARS = "a-zA-Z0-9._";
     String EXTENDED_NAME_CHARS = NAME_CHARS + "~\\^";
     String NAME_HYPHEN_CHARS = "-" + EXTENDED_NAME_CHARS;
-    String PUSH_FORMAT = "v([0-9]{3})";
+    String PUSH_FORMAT = "v([0-9]{3,6})";
 
     String COUNTRIES_KEY = "c";
     String DEV_PHASE_KEY = "d";

--- a/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
+++ b/src/test/groovy/com/netflix/frigga/NamesSpec.groovy
@@ -47,6 +47,30 @@ class NamesSpec extends Specification {
         null == names.sequence
     }
 
+    def 'supports 3-6 digit push sequence'() {
+        when:
+        Names names = Names.parseName(name)
+
+        then:
+        group == names.group
+        cluster == names.cluster
+        app == names.app
+        stack == names.stack
+        detail == names.detail
+        push == names.push
+        sequence == names.sequence
+
+        where:
+        name           || group          || cluster        || app   || stack      || detail || push      || sequence
+        'foo-v1'       || 'foo-v1'       || 'foo-v1'       || 'foo' || 'v1'       || null   || null      || null
+        'foo-v01'      || 'foo-v01'      || 'foo-v01'      || 'foo' || 'v01'      || null   || null      || null
+        'foo-v001'     || 'foo-v001'     || 'foo'          || 'foo' || null       || null   || 'v001'    || 1
+        'foo-v0001'    || 'foo-v0001'    || 'foo'          || 'foo' || null       || null   || 'v0001'   || 1
+        'foo-v00001'   || 'foo-v00001'   || 'foo'          || 'foo' || null       || null   || 'v00001'  || 1
+        'foo-v000001'  || 'foo-v000001'  || 'foo'          || 'foo' || null       || null   || 'v000001' || 1
+        'foo-v0000001' || 'foo-v0000001' || 'foo-v0000001' || 'foo' || 'v0000001' || null   || null      || null
+    }
+
     def 'should dissect group names'() {
         when:
         Names names = Names.parseName(null)


### PR DESCRIPTION
need to not break some existing deploys using a 6 digit sequence number, but this is still small enough
that tracking a standard width git short sha (8 characters) won't conflict.