### PR TITLE
updates AppVersion to ignore target distribution suffix

### DIFF
--- a/src/main/java/com/netflix/frigga/ami/AppVersion.java
+++ b/src/main/java/com/netflix/frigga/ami/AppVersion.java
@@ -33,7 +33,7 @@ public class AppVersion implements Comparable<AppVersion> {
      */
     private static final Pattern APP_VERSION_PATTERN = Pattern.compile(
             "([" + NameConstants.NAME_HYPHEN_CHARS
-            + "]+)-([0-9.a-zA-Z~]+)-(\\w+)(?:[.](\\w+))?(?:\\/([" + NameConstants.NAME_HYPHEN_CHARS + "]+)\\/([0-9]+))?");
+            + "]+)-([0-9.a-zA-Z~]+)-(\\w+)(?:[.](\\w+))?(?:~[" + NameConstants.NAME_HYPHEN_CHARS + "]+)?(?:\\/([" + NameConstants.NAME_HYPHEN_CHARS + "]+)\\/([0-9]+))?");
 
 
     private String packageName;

--- a/src/test/groovy/com/netflix/frigga/ami/AppVersionTest.groovy
+++ b/src/test/groovy/com/netflix/frigga/ami/AppVersionTest.groovy
@@ -113,12 +113,15 @@ class AppVersionTest extends Specification {
         appversionString                                              | packageName | version                      | commit     | buildNumber | buildJob
         'appName-0.1-9b3bc237.h150'                                   | 'appName'   | '0.1'                        | '9b3bc237' | '150'       | null
         'appName-0.1-9b3bc237.h150'                                   | 'appName'   | '0.1'                        | '9b3bc237' | '150'       | null
+        'appName-0.1-h150.9b3bc237~focal'                             | 'appName'   | '0.1'                        | '9b3bc237' | '150'       | null
+        'appName-0.1-h150.9b3bc237~focal/mybuild/150'                 | 'appName'   | '0.1'                        | '9b3bc237' | '150'       | 'mybuild'
         'appName-0.1b34-9b3bc237.h150'                                | 'appName'   | '0.1b34'                     | '9b3bc237' | '150'       | null
         'appName-0.1-1630379'                                         | 'appName'   | '0.1'                        | '1630379'  | null        | null
         'appName-0.1-1'                                               | 'appName'   | '0.1'                        | '1'        | null        | null
         'appName-0.1-abcd6789'                                        | 'appName'   | '0.1'                        | 'abcd6789' | null        | null
         'appName-0.1~rc.1-1630379'                                    | 'appName'   | '0.1~rc.1'                   | '1630379'  | null        | null
         'appName-0.1~dev.1-9b3bc237.h150'                             | 'appName'   | '0.1~dev.1'                  | '9b3bc237' | '150'       | null
+        'appName-0.1~dev.1-h150.9b3bc237~focal'                       | 'appName'   | '0.1~dev.1'                  | '9b3bc237' | '150'       | null
         'appName-0.1~dev.3.uncommitted-h0.54f3416'                    | 'appName'   | '0.1~dev.3.uncommitted'      | '54f3416'  | '0'         | null
         'testApp-1.3.0-h196/mybuild/196'                              | 'testApp'   | '1.3.0'                      | null       | '196'       | 'mybuild'
         'testApp-1.3.0-h196.9b3bc237/mybuild/196'                     | 'testApp'   | '1.3.0'                      | '9b3bc237' | '196'       | 'mybuild'


### PR DESCRIPTION
This supports newer versioning that includes the target distribution as part of the version string.

For now, this is just ignored instead of failing to parse.